### PR TITLE
fix: disable pinch-to-zoom on mobile

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/icon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="theme-color" content="#ffffff" />
     <link rel="apple-touch-icon" href="/icon-192x192.png" />
     <title>Miam</title>


### PR DESCRIPTION
Users could to zoom in the mobile app, which is not usual in such apps. Removed it.