### PR TITLE
Fix/UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,7 +13,7 @@ import { AuthProvider } from "./contexts/AuthContext";
 import ProtectedRoute from "./components/ProtectedRoute";
 import SwipeBack from "./components/SwipeBack";
 import MobileBottomBar from "./components/MobileBottomBar";
-import CatalogPage from "./pages/CatalogPage";
+import CatalogLayout from "./components/CatalogLayout";
 import LoginPage from "./pages/LoginPage";
 
 const RecipeDetailPage = lazy(() => import("./pages/RecipeDetailPage"));
@@ -59,10 +59,12 @@ const App = () => (
           <Suspense>
           <Routes>
             <Route path="/login" element={<LoginPage />} />
-            <Route path="/" element={<ProtectedRoute><CatalogPage /></ProtectedRoute>} />
+            <Route path="/" element={<ProtectedRoute><CatalogLayout /></ProtectedRoute>}>
+              <Route index element={null} />
+              <Route path="recipes/:id" element={<RecipeDetailPage />} />
+              <Route path="recipes/new" element={<CreateRecipePage />} />
+            </Route>
             <Route path="/add" element={<ProtectedRoute><AddRecipePage /></ProtectedRoute>} />
-            <Route path="/recipes/new" element={<ProtectedRoute><CreateRecipePage /></ProtectedRoute>} />
-            <Route path="/recipes/:id" element={<ProtectedRoute><RecipeDetailPage /></ProtectedRoute>} />
             <Route path="/import/ocr" element={<ProtectedRoute><ImportOCRPage /></ProtectedRoute>} />
             <Route path="/import/json" element={<ProtectedRoute><ImportJSONPage /></ProtectedRoute>} />
             <Route path="/import/instagram" element={<ProtectedRoute><ImportInstagramPage /></ProtectedRoute>} />

--- a/frontend/src/components/CartSheet.tsx
+++ b/frontend/src/components/CartSheet.tsx
@@ -213,26 +213,26 @@ export default function CartSheet({ trigger, hotkey }: { trigger?: React.ReactNo
           <div className="flex-1 overflow-y-auto space-y-6 pr-2">
             {/* Selected recipes */}
             <div className="space-y-2">
-              <h3 className="font-display text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+              <h3 className="font-display text-base font-semibold text-muted-foreground uppercase tracking-wide">
                 Recettes sélectionnées
               </h3>
               {cartRecipes.map((recipe) => (
-                <div key={recipe.id} className="flex items-center gap-3 p-2 rounded-lg bg-secondary/50 group">
+                <div key={recipe.id} className="flex items-center gap-3 p-3 rounded-lg bg-secondary/50 group">
                   {recipe.image ? (
-                    <AuthImage src={recipe.image} alt={recipe.title} className="w-12 h-12 rounded object-cover shrink-0" />
+                    <AuthImage src={recipe.image} alt={recipe.title} className="w-14 h-14 rounded-md object-cover shrink-0" />
                   ) : (
-                    <div className="w-12 h-12 rounded bg-muted shrink-0" />
+                    <div className="w-14 h-14 rounded-md bg-muted shrink-0" />
                   )}
                   <div className="flex-1 min-w-0">
-                    <p className="font-body text-sm font-medium truncate">{recipe.title}</p>
-                    <p className="text-xs text-muted-foreground font-body">{recipe.servings} pers. · {recipe.ingredients.length} ingrédients</p>
+                    <p className="font-body text-base font-medium truncate">{recipe.title}</p>
+                    <p className="text-sm text-muted-foreground font-body">{recipe.servings} pers. · {recipe.ingredients.length} ingrédients</p>
                   </div>
                   <button
                     onClick={() => remove(recipe.id)}
-                    className="shrink-0 p-1.5 rounded-full text-muted-foreground md:text-muted-foreground/0 md:group-hover:text-muted-foreground hover:!text-destructive hover:bg-destructive/10 transition-colors"
+                    className="shrink-0 p-2 rounded-full text-muted-foreground md:text-muted-foreground/0 md:group-hover:text-muted-foreground hover:!text-destructive hover:bg-destructive/10 transition-colors"
                     title="Retirer du panier"
                   >
-                    <X size={16} />
+                    <X size={20} />
                   </button>
                 </div>
               ))}
@@ -241,12 +241,12 @@ export default function CartSheet({ trigger, hotkey }: { trigger?: React.ReactNo
             {/* Shopping list preview */}
             {ingredients.length > 0 && (
               <div className="space-y-2">
-                <h3 className="font-display text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+                <h3 className="font-display text-base font-semibold text-muted-foreground uppercase tracking-wide">
                   Liste de courses
                 </h3>
                 <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
                   <SortableContext items={sortedIngredients.map((i) => i.id)} strategy={verticalListSortingStrategy}>
-                    <ul className="space-y-1">
+                    <ul className="space-y-1.5">
                       {sortedIngredients.map((ing) => (
                         <SortableCartIngredientItem
                           key={ing.id}
@@ -269,12 +269,12 @@ export default function CartSheet({ trigger, hotkey }: { trigger?: React.ReactNo
         {/* Actions */}
         {cartRecipes.length > 0 && (
           <div className="border-t pt-4 space-y-2">
-            <Button onClick={copyShoppingList} className="w-full gradient-warm text-primary-foreground font-body font-semibold gap-2">
-              <ClipboardCopy size={16} />
+            <Button onClick={copyShoppingList} className="w-full gradient-warm text-primary-foreground font-body font-semibold gap-2 h-12 text-base">
+              <ClipboardCopy size={20} />
               Copier la liste de courses
             </Button>
-            <Button onClick={clear} variant="ghost" className="w-full font-body text-muted-foreground gap-2">
-              <Trash2 size={16} />
+            <Button onClick={clear} variant="ghost" className="w-full font-body text-muted-foreground gap-2 h-12 text-base">
+              <Trash2 size={20} />
               Vider le panier
             </Button>
           </div>

--- a/frontend/src/components/CartSheet.tsx
+++ b/frontend/src/components/CartSheet.tsx
@@ -213,7 +213,7 @@ export default function CartSheet({ trigger, hotkey }: { trigger?: React.ReactNo
           <div className="flex-1 overflow-y-auto space-y-6 pr-2">
             {/* Selected recipes */}
             <div className="space-y-2">
-              <h3 className="font-display text-base font-semibold text-muted-foreground uppercase tracking-wide">
+              <h3 className="font-body text-base font-semibold text-muted-foreground uppercase tracking-wide">
                 Recettes sélectionnées
               </h3>
               {cartRecipes.map((recipe) => (
@@ -241,7 +241,7 @@ export default function CartSheet({ trigger, hotkey }: { trigger?: React.ReactNo
             {/* Shopping list preview */}
             {ingredients.length > 0 && (
               <div className="space-y-2">
-                <h3 className="font-display text-base font-semibold text-muted-foreground uppercase tracking-wide">
+                <h3 className="font-body text-base font-semibold text-muted-foreground uppercase tracking-wide">
                   Liste de courses
                 </h3>
                 <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>

--- a/frontend/src/components/CatalogLayout.tsx
+++ b/frontend/src/components/CatalogLayout.tsx
@@ -1,0 +1,66 @@
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { createContext, useCallback, useContext, useEffect, useRef, useState, Suspense } from 'react';
+import CatalogPage from '@/pages/CatalogPage';
+import { useIsMobile } from '@/hooks/use-mobile';
+
+interface OverlayContextValue {
+  requestClose: (to: string) => void;
+}
+
+const OverlayContext = createContext<OverlayContextValue>({ requestClose: () => {} });
+
+export function useOverlayClose() {
+  return useContext(OverlayContext);
+}
+
+export default function CatalogLayout() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const isMobile = useIsMobile();
+  const [exiting, setExiting] = useState(false);
+  const exitTarget = useRef('/');
+
+  const hasOverlay = location.pathname !== '/';
+
+  // Reset exiting flag once navigation has completed
+  useEffect(() => {
+    setExiting(false);
+  }, [location.pathname]);
+
+  const requestClose = useCallback((to: string) => {
+    if (isMobile) {
+      exitTarget.current = to;
+      setExiting(true);
+    } else {
+      navigate(to);
+    }
+  }, [isMobile, navigate]);
+
+  const handleAnimationEnd = useCallback(() => {
+    if (exiting) {
+      navigate(exitTarget.current);
+    }
+  }, [exiting, navigate]);
+
+  return (
+    <OverlayContext.Provider value={{ requestClose }}>
+      <CatalogPage />
+      {(hasOverlay || exiting) && (
+        <div
+          className={`fixed inset-0 z-40 bg-background overflow-y-auto overscroll-contain ${
+            isMobile
+              ? exiting
+                ? 'animate-slide-out-to-right'
+                : 'animate-slide-in-from-right'
+              : ''
+          }`}
+          onAnimationEnd={handleAnimationEnd}
+        >
+          <Suspense>
+            <Outlet />
+          </Suspense>
+        </div>
+      )}
+    </OverlayContext.Provider>
+  );
+}

--- a/frontend/src/components/MobileBottomBar.tsx
+++ b/frontend/src/components/MobileBottomBar.tsx
@@ -1,3 +1,4 @@
+import { useState, useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { BookOpen, Share2, Plus, ShoppingCart, UserRound } from 'lucide-react';
 import { useCart } from '@/contexts/CartContext';
@@ -11,6 +12,13 @@ export default function MobileBottomBar() {
   const navigate = useNavigate();
   const { count } = useCart();
   const { user } = useAuth();
+  const [tappedTab, setTappedTab] = useState<string | null>(null);
+
+  const handleTap = useCallback((tab: string, path: string) => {
+    setTappedTab(tab);
+    navigate(path);
+    setTimeout(() => setTappedTab(null), 400);
+  }, [navigate]);
 
   if (!user) return null;
 
@@ -21,73 +29,94 @@ export default function MobileBottomBar() {
   const isAccount = location.pathname === '/settings';
 
   return (
-    <nav className={`fixed bottom-0 inset-x-0 z-30 md:hidden bg-background border-t border-border transition-transform duration-300 ${hidden ? 'translate-y-full' : 'translate-y-0'}`}>
-      <div className="flex items-center justify-around h-16 px-2 pb-[env(safe-area-inset-bottom)]">
-        {/* Recipes */}
-        <button
-          onClick={() => navigate('/')}
-          className={`flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors ${
-            isRecipes ? 'text-primary' : 'text-muted-foreground'
-          }`}
-        >
-          <BookOpen size={22} strokeWidth={isRecipes ? 2.5 : 2} />
-          <span className="text-[11px] font-body font-medium">Recettes</span>
-        </button>
+    <>
+      <style>{`
+        @keyframes pill-flash {
+          0% { opacity: 0; transform: scale(0.8); }
+          30% { opacity: 1; transform: scale(1); }
+          100% { opacity: 0; transform: scale(1); }
+        }
+        .tap-pill::after {
+          content: '';
+          position: absolute;
+          inset: 6px 8px;
+          border-radius: 12px;
+          background: hsl(var(--primary) / 0.15);
+          opacity: 0;
+          pointer-events: none;
+        }
+        .tap-pill-active::after {
+          animation: pill-flash 400ms ease-out forwards;
+        }
+      `}</style>
+      <nav className={`fixed bottom-0 inset-x-0 z-30 md:hidden bg-background border-t border-border transition-transform duration-300 ${hidden ? 'translate-y-full' : 'translate-y-0'}`}>
+        <div className="flex items-center justify-around h-16 px-2 pb-[env(safe-area-inset-bottom)]">
+          {/* Recipes */}
+          <button
+            onClick={() => handleTap('recipes', '/')}
+            className={`tap-pill ${tappedTab === 'recipes' ? 'tap-pill-active' : ''} relative flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors ${
+              isRecipes ? 'text-primary' : 'text-muted-foreground'
+            }`}
+          >
+            <BookOpen size={22} strokeWidth={isRecipes ? 2.5 : 2} />
+            <span className="text-[11px] font-body font-medium">Recettes</span>
+          </button>
 
-        {/* Add */}
-        <button
-          onClick={() => navigate('/add')}
-          className={`flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors ${
-            isAdd ? 'text-primary' : 'text-muted-foreground'
-          }`}
-        >
-          <Plus size={22} strokeWidth={isAdd ? 2.5 : 2} />
-          <span className="text-[11px] font-body font-medium">Ajouter</span>
-        </button>
+          {/* Add */}
+          <button
+            onClick={() => handleTap('add', '/add')}
+            className={`tap-pill ${tappedTab === 'add' ? 'tap-pill-active' : ''} relative flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors ${
+              isAdd ? 'text-primary' : 'text-muted-foreground'
+            }`}
+          >
+            <Plus size={22} strokeWidth={isAdd ? 2.5 : 2} />
+            <span className="text-[11px] font-body font-medium">Ajouter</span>
+          </button>
 
-        {/* Cart */}
-        <button
-          onClick={() => navigate('/cart')}
-          className={`flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors ${
-            isCart ? 'text-primary' : 'text-muted-foreground'
-          }`}
-        >
-          <span className="relative">
-            <ShoppingCart size={22} strokeWidth={isCart ? 2.5 : 2} />
-            {count > 0 && (
-              <span className="absolute -top-1.5 -right-2.5 w-4 h-4 rounded-full bg-primary text-primary-foreground text-[10px] flex items-center justify-center font-bold">
-                {count}
-              </span>
-            )}
-          </span>
-          <span className="text-[11px] font-body font-medium">Panier</span>
-        </button>
+          {/* Cart */}
+          <button
+            onClick={() => handleTap('cart', '/cart')}
+            className={`tap-pill ${tappedTab === 'cart' ? 'tap-pill-active' : ''} relative flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors ${
+              isCart ? 'text-primary' : 'text-muted-foreground'
+            }`}
+          >
+            <span className="relative">
+              <ShoppingCart size={22} strokeWidth={isCart ? 2.5 : 2} />
+              {count > 0 && (
+                <span className="absolute -top-1.5 -right-2.5 w-4 h-4 rounded-full bg-primary text-primary-foreground text-[10px] flex items-center justify-center font-bold">
+                  {count}
+                </span>
+              )}
+            </span>
+            <span className="text-[11px] font-body font-medium">Panier</span>
+          </button>
 
-        {/* Shares */}
-        <button
-          onClick={() => navigate('/shares')}
-          className={`flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors ${
-            isShares ? 'text-primary' : 'text-muted-foreground'
-          }`}
-        >
-          <span className="relative">
-            <Share2 size={22} strokeWidth={isShares ? 2.5 : 2} />
-            <PendingSharesBadge />
-          </span>
-          <span className="text-[11px] font-body font-medium">Partages</span>
-        </button>
+          {/* Shares */}
+          <button
+            onClick={() => handleTap('shares', '/shares')}
+            className={`tap-pill ${tappedTab === 'shares' ? 'tap-pill-active' : ''} relative flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors ${
+              isShares ? 'text-primary' : 'text-muted-foreground'
+            }`}
+          >
+            <span className="relative">
+              <Share2 size={22} strokeWidth={isShares ? 2.5 : 2} />
+              <PendingSharesBadge />
+            </span>
+            <span className="text-[11px] font-body font-medium">Partages</span>
+          </button>
 
-        {/* Account */}
-        <button
-          onClick={() => navigate('/settings')}
-          className={`flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors ${
-            isAccount ? 'text-primary' : 'text-muted-foreground'
-          }`}
-        >
-          <UserRound size={22} strokeWidth={isAccount ? 2.5 : 2} />
-          <span className="text-[11px] font-body font-medium">Compte</span>
-        </button>
-      </div>
-    </nav>
+          {/* Account */}
+          <button
+            onClick={() => handleTap('account', '/settings')}
+            className={`tap-pill ${tappedTab === 'account' ? 'tap-pill-active' : ''} relative flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors ${
+              isAccount ? 'text-primary' : 'text-muted-foreground'
+            }`}
+          >
+            <UserRound size={22} strokeWidth={isAccount ? 2.5 : 2} />
+            <span className="text-[11px] font-body font-medium">Compte</span>
+          </button>
+        </div>
+      </nav>
+    </>
   );
 }

--- a/frontend/src/components/MobileHeader.tsx
+++ b/frontend/src/components/MobileHeader.tsx
@@ -1,6 +1,7 @@
 import { KeyboardEvent, useRef, useEffect } from 'react';
 import { Search, X, SlidersHorizontal } from 'lucide-react';
 import { useScrollDirection } from '@/hooks/use-scroll-direction';
+import { useLongPress } from '@/hooks/use-long-press';
 
 interface MobileHeaderProps {
   searchTags: string[];
@@ -11,6 +12,8 @@ interface MobileHeaderProps {
   hasActiveFilters?: boolean;
   inlineSearch: boolean;
   onInlineSearchChange: (open: boolean) => void;
+  onLogoTap?: () => void;
+  onLogoLongPress?: () => void;
 }
 
 export default function MobileHeader({
@@ -18,9 +21,14 @@ export default function MobileHeader({
   searchQuery, onSearchQueryChange,
   onFiltersTap, hasActiveFilters,
   inlineSearch, onInlineSearchChange,
+  onLogoTap, onLogoLongPress,
 }: MobileHeaderProps) {
   const { headerOffset } = useScrollDirection();
   const inputRef = useRef<HTMLInputElement>(null);
+  const logoHandlers = useLongPress(
+    () => onLogoTap?.(),
+    () => onLogoLongPress?.(),
+  );
 
   useEffect(() => {
     if (inlineSearch) {
@@ -57,7 +65,13 @@ export default function MobileHeader({
       className="sticky top-0 z-20 flex items-center gap-3 px-3 h-14 bg-background border-b border-border md:hidden will-change-transform"
       style={{ transform: `translateY(${headerOffset}px)` }}
     >
-      <img src="/icon.png" alt="Miam" className="w-8 h-8 shrink-0" />
+      <img
+        src="/icon.png"
+        alt="Miam"
+        className="w-8 h-8 shrink-0 select-none"
+        draggable={false}
+        {...logoHandlers}
+      />
 
       <div className="flex-1 flex items-center gap-1.5 flex-wrap min-h-9 px-2.5 bg-secondary/60 border border-border rounded-lg transition-colors">
         {inlineSearch ? (

--- a/frontend/src/components/MobileHeader.tsx
+++ b/frontend/src/components/MobileHeader.tsx
@@ -1,7 +1,7 @@
 import { KeyboardEvent, useRef, useEffect } from 'react';
 import { Search, X, SlidersHorizontal } from 'lucide-react';
 import { useScrollDirection } from '@/hooks/use-scroll-direction';
-import { useLongPress } from '@/hooks/use-long-press';
+import { useShakeEscalation } from '@/hooks/use-shake-escalation';
 
 interface MobileHeaderProps {
   searchTags: string[];
@@ -25,7 +25,7 @@ export default function MobileHeader({
 }: MobileHeaderProps) {
   const { headerOffset } = useScrollDirection();
   const inputRef = useRef<HTMLInputElement>(null);
-  const logoHandlers = useLongPress(
+  const { ref: logoRef, handlers: logoHandlers } = useShakeEscalation(
     () => onLogoTap?.(),
     () => onLogoLongPress?.(),
   );
@@ -66,9 +66,11 @@ export default function MobileHeader({
       style={{ transform: `translateY(${headerOffset}px)` }}
     >
       <img
+        ref={logoRef}
         src="/icon.png"
         alt="Miam"
         className="w-8 h-8 shrink-0 select-none"
+        style={{ WebkitTouchCallout: 'none' }}
         draggable={false}
         {...logoHandlers}
       />

--- a/frontend/src/components/MobileSearchOverlay.tsx
+++ b/frontend/src/components/MobileSearchOverlay.tsx
@@ -129,7 +129,7 @@ export default function MobileSearchOverlay({
   return (
     <div
       className={`fixed inset-0 z-50 bg-background flex flex-col md:hidden transition-transform duration-300 ease-out ${
-        visible ? 'translate-y-0' : 'translate-y-full'
+        visible ? 'translate-x-0' : 'translate-x-full'
       }`}
     >
       {/* Search header */}

--- a/frontend/src/components/RecipeCard.tsx
+++ b/frontend/src/components/RecipeCard.tsx
@@ -39,7 +39,7 @@ const StarRating = ({ rating, size = 14 }: { rating: number; size?: number }) =>
       <Star
         key={i}
         size={size}
-        className={i <= rating ? 'fill-primary text-primary' : 'text-muted'}
+        className={i <= rating ? 'fill-primary text-primary' : 'text-white/30'}
       />
     ))}
   </div>
@@ -89,7 +89,7 @@ export default function RecipeCard({ recipe, onClick, selectionMode, selected, o
             </div>
           )}
           {/* Gradient overlay */}
-          <div className="absolute inset-0 bg-gradient-to-t from-foreground/50 to-transparent" />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent" />
 
           {/* Top right: selection check or cart button */}
           <div className="absolute top-2 right-2">

--- a/frontend/src/components/RecipeCard.tsx
+++ b/frontend/src/components/RecipeCard.tsx
@@ -80,11 +80,11 @@ export default function RecipeCard({ recipe, onClick, selectionMode, selected, o
             <img
               src={imageSrc}
               alt={recipe.title}
-              className={`w-full h-full object-cover ${!recipe.tested ? 'opacity-60 saturate-[0.3]' : ''}`}
+              className="w-full h-full object-cover"
               loading="lazy"
             />
           ) : (
-            <div className={`w-full h-full bg-muted flex items-center justify-center ${!recipe.tested ? 'opacity-60' : ''}`}>
+            <div className="w-full h-full bg-muted flex items-center justify-center">
               <img src={beaverIcon} alt="Pas d'image" className="w-10 h-10 opacity-50 grayscale" />
             </div>
           )}
@@ -149,11 +149,11 @@ export default function RecipeCard({ recipe, onClick, selectionMode, selected, o
           <img
             src={imageSrc}
             alt={recipe.title}
-            className={`w-full h-full object-cover group-hover:scale-105 transition-transform duration-500 ${!recipe.tested ? 'opacity-60 saturate-[0.3]' : ''}`}
+            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
             loading="lazy"
           />
         ) : (
-          <div className={`w-full h-full bg-muted flex items-center justify-center ${!recipe.tested ? 'opacity-60' : ''}`}>
+          <div className="w-full h-full bg-muted flex items-center justify-center">
             <img src={beaverIcon} alt="Pas d'image" className="w-10 h-10 opacity-50 grayscale" />
           </div>
         )}

--- a/frontend/src/components/RecipeDetail.tsx
+++ b/frontend/src/components/RecipeDetail.tsx
@@ -262,7 +262,7 @@ export default function RecipeDetail({ recipe, onBack, onRatingChange, onSave, o
       )}
 
       {/* Header image */}
-      <div className={`animate-fade-in relative h-[300px] md:h-[400px] overflow-hidden select-none ${editing ? 'mt-14' : ''}`}>
+      <div className={`relative h-[300px] md:h-[400px] overflow-hidden select-none ${editing ? 'mt-14' : ''}`}>
         {imageSrc ? (
           <img src={imageSrc} alt={current.title} className="w-full h-full object-cover" />
         ) : (

--- a/frontend/src/components/RecipeForm.tsx
+++ b/frontend/src/components/RecipeForm.tsx
@@ -224,7 +224,7 @@ export default function RecipeForm({ onBack, onSave, initialRecipe, allTags = []
       )}
 
       {/* Hero image area */}
-      <div className={`animate-fade-in relative h-[300px] md:h-[400px] overflow-hidden ${errors.length > 0 ? 'mt-24' : 'mt-14'}`}>
+      <div className={`relative h-[300px] md:h-[400px] overflow-hidden ${errors.length > 0 ? 'mt-24' : 'mt-14'}`}>
         {data.image ? (
           <img src={data.image} alt={data.title} className="w-full h-full object-cover" />
         ) : (

--- a/frontend/src/components/RecipeImportJSON.tsx
+++ b/frontend/src/components/RecipeImportJSON.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from 'react';
-import { Upload, FileJson, ArrowLeft, AlertCircle } from 'lucide-react';
+import { Upload, FileJson, ArrowLeft, AlertCircle, ClipboardPaste } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/hooks/use-toast';
 import { importRecipesBatch, fetchRecipes } from '@/lib/api';
@@ -15,11 +15,30 @@ export default function RecipeImportJSON({ onBack, onImportRecipes }: RecipeImpo
   const [jsonData, setJsonData] = useState<{ recipes: unknown[] } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [importing, setImporting] = useState(false);
+  const [pasteMode, setPasteMode] = useState(false);
+  const [pasteValue, setPasteValue] = useState('');
   const fileRef = useRef<HTMLInputElement>(null);
 
-  const handleFile = (file: File) => {
+  const parseRawJson = (text: string) => {
     setError(null);
     setJsonData(null);
+    try {
+      const parsed = JSON.parse(text);
+      if (!parsed.recipes || !Array.isArray(parsed.recipes)) {
+        setError('Le JSON doit contenir une clé "recipes" avec un tableau.');
+        return;
+      }
+      if (parsed.recipes.length === 0) {
+        setError('Le tableau "recipes" est vide.');
+        return;
+      }
+      setJsonData(parsed);
+    } catch {
+      setError('Le contenu ne contient pas du JSON valide.');
+    }
+  };
+
+  const handleFile = (file: File) => {
     setFileName(file.name);
 
     if (!file.name.endsWith('.json')) {
@@ -28,23 +47,18 @@ export default function RecipeImportJSON({ onBack, onImportRecipes }: RecipeImpo
     }
 
     const reader = new FileReader();
-    reader.onload = (e) => {
-      try {
-        const parsed = JSON.parse(e.target?.result as string);
-        if (!parsed.recipes || !Array.isArray(parsed.recipes)) {
-          setError('Le JSON doit contenir une clé "recipes" avec un tableau.');
-          return;
-        }
-        if (parsed.recipes.length === 0) {
-          setError('Le tableau "recipes" est vide.');
-          return;
-        }
-        setJsonData(parsed);
-      } catch {
-        setError('Le fichier ne contient pas du JSON valide.');
-      }
-    };
+    reader.onload = (e) => parseRawJson(e.target?.result as string);
     reader.readAsText(file);
+  };
+
+  const handlePaste = () => {
+    const text = pasteValue.trim();
+    if (!text) {
+      setError('Veuillez coller du contenu JSON.');
+      return;
+    }
+    setFileName(null);
+    parseRawJson(text);
   };
 
   const handleDrop = (e: React.DragEvent) => {
@@ -87,30 +101,72 @@ export default function RecipeImportJSON({ onBack, onImportRecipes }: RecipeImpo
       </header>
       <div className="max-w-4xl mx-auto px-4 py-8">
       <p className="font-body text-muted-foreground mb-6 text-sm">
-        Uploadez un fichier JSON contenant vos recettes au format <code className="bg-muted px-1 py-0.5 rounded text-xs">{'{ "recipes": [...] }'}</code>
+        Importez vos recettes au format <code className="bg-muted px-1 py-0.5 rounded text-xs">{'{ "recipes": [...] }'}</code> : déposez un fichier ou collez le contenu directement.
       </p>
 
       <div className="space-y-6">
-        {/* Upload zone */}
-        <div
-          onClick={() => fileRef.current?.click()}
-          onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); }}
-          onDrop={handleDrop}
-          className="border-2 border-dashed border-border rounded-lg p-8 text-center cursor-pointer hover:border-primary/50 hover:bg-primary/5 transition-colors"
-        >
-          <input
-            ref={fileRef}
-            type="file"
-            accept=".json"
-            className="hidden"
-            onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])}
-          />
-          <div className="flex flex-col items-center gap-3 text-muted-foreground">
-            <Upload size={40} />
-            <span className="font-body">Cliquez ou glissez un fichier JSON ici</span>
-            <span className="font-body text-xs">.json uniquement</span>
+        {/* Input selection */}
+        {!jsonData && !pasteMode && (
+          <div className="grid grid-cols-2 gap-3">
+            <div
+              onClick={() => fileRef.current?.click()}
+              onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); }}
+              onDrop={handleDrop}
+              className="border-2 border-dashed border-border rounded-lg p-6 text-center cursor-pointer hover:border-primary/50 hover:bg-primary/5 transition-colors"
+            >
+              <input
+                ref={fileRef}
+                type="file"
+                accept=".json"
+                className="hidden"
+                onChange={(e) => e.target.files?.[0] && handleFile(e.target.files[0])}
+              />
+              <div className="flex flex-col items-center gap-3 text-muted-foreground">
+                <Upload size={32} />
+                <span className="font-body text-sm">Déposer un fichier JSON</span>
+              </div>
+            </div>
+            <div
+              onClick={() => setPasteMode(true)}
+              className="border-2 border-dashed border-border rounded-lg p-6 text-center cursor-pointer hover:border-primary/50 hover:bg-primary/5 transition-colors"
+            >
+              <div className="flex flex-col items-center gap-3 text-muted-foreground">
+                <ClipboardPaste size={32} />
+                <span className="font-body text-sm">Coller du JSON</span>
+              </div>
+            </div>
           </div>
-        </div>
+        )}
+
+        {/* Paste mode */}
+        {!jsonData && pasteMode && (
+          <div className="space-y-3">
+            <textarea
+              value={pasteValue}
+              onChange={(e) => setPasteValue(e.target.value)}
+              placeholder='Collez le contenu JSON ici...'
+              className="w-full h-48 rounded-lg border border-border bg-card p-3 font-mono text-xs resize-y focus:outline-none focus:ring-2 focus:ring-primary/50"
+              autoFocus
+            />
+            <div className="flex gap-3">
+              <Button
+                variant="outline"
+                className="font-body"
+                onClick={() => { setPasteMode(false); setPasteValue(''); setError(null); }}
+              >
+                <ArrowLeft size={16} className="mr-2" />
+                Retour
+              </Button>
+              <Button
+                onClick={handlePaste}
+                disabled={!pasteValue.trim()}
+                className="font-body gradient-warm text-primary-foreground font-semibold"
+              >
+                Analyser
+              </Button>
+            </div>
+          </div>
+        )}
 
         {/* Error */}
         {error && (
@@ -126,7 +182,7 @@ export default function RecipeImportJSON({ onBack, onImportRecipes }: RecipeImpo
             <div className="flex items-center gap-3 border border-border rounded-lg p-4 bg-muted/30">
               <FileJson size={24} className="text-primary" />
               <div className="flex-1 min-w-0">
-                <p className="font-body font-semibold text-foreground truncate">{fileName}</p>
+                <p className="font-body font-semibold text-foreground truncate">{fileName ?? 'JSON collé'}</p>
                 <p className="font-body text-sm text-muted-foreground">
                   {jsonData.recipes.length} recette{jsonData.recipes.length > 1 ? 's' : ''} détectée{jsonData.recipes.length > 1 ? 's' : ''}
                 </p>
@@ -134,7 +190,7 @@ export default function RecipeImportJSON({ onBack, onImportRecipes }: RecipeImpo
             </div>
 
             <div className="flex gap-3">
-              <Button onClick={onBack} variant="outline" className="font-body flex-1 h-12">Annuler</Button>
+              <Button onClick={() => { setJsonData(null); setFileName(null); setPasteMode(false); setPasteValue(''); }} variant="outline" className="font-body flex-1 h-12">Annuler</Button>
               <Button
                 onClick={handleImport}
                 disabled={importing}

--- a/frontend/src/components/SortableCartIngredientItem.tsx
+++ b/frontend/src/components/SortableCartIngredientItem.tsx
@@ -31,27 +31,27 @@ export function SortableCartIngredientItem({ id, name, details, checked, onToggl
     <li
       ref={setNodeRef}
       style={style}
-      className={`flex items-center gap-2 font-body text-sm group ${checked ? 'text-muted-foreground' : ''}`}
+      className={`flex items-center gap-3 py-0.5 font-body text-base group ${checked ? 'text-muted-foreground' : ''}`}
     >
       <button
         type="button"
-        className="cursor-grab active:cursor-grabbing text-muted-foreground md:text-muted-foreground/0 md:group-hover:text-muted-foreground hover:!text-foreground touch-none shrink-0 transition-colors"
+        className="cursor-grab active:cursor-grabbing text-muted-foreground md:text-muted-foreground/0 md:group-hover:text-muted-foreground hover:!text-foreground touch-none shrink-0 transition-colors p-1"
         {...attributes}
         {...listeners}
       >
-        <GripVertical size={14} />
+        <GripVertical size={20} />
       </button>
       <button
         type="button"
         onClick={() => onToggle(id)}
-        className={`w-4 h-4 shrink-0 rounded border transition-colors flex items-center justify-center ${
+        className={`w-6 h-6 shrink-0 rounded border-2 transition-colors flex items-center justify-center ${
           checked
             ? 'bg-primary border-primary text-primary-foreground'
             : 'border-muted-foreground/30 hover:border-primary'
         }`}
       >
         {checked && (
-          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <svg width="14" height="14" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
             <path d="M2 5.5L4 7.5L8 3" />
           </svg>
         )}
@@ -62,10 +62,10 @@ export function SortableCartIngredientItem({ id, name, details, checked, onToggl
       </span>
       <button
         onClick={() => onRemove(id)}
-        className="shrink-0 p-1 rounded-full text-muted-foreground md:text-muted-foreground/0 md:group-hover:text-muted-foreground hover:!text-destructive transition-colors"
+        className="shrink-0 p-2 rounded-full text-muted-foreground md:text-muted-foreground/0 md:group-hover:text-muted-foreground hover:!text-destructive transition-colors"
         title="Retirer de la liste"
       >
-        <X size={14} />
+        <X size={20} />
       </button>
     </li>
   );

--- a/frontend/src/hooks/use-long-press.ts
+++ b/frontend/src/hooks/use-long-press.ts
@@ -1,0 +1,42 @@
+import { useRef, useCallback } from 'react';
+
+const LONG_PRESS_MS = 5000;
+
+export function useLongPress(
+  onTap: () => void,
+  onLongPress: () => void,
+) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const firedRef = useRef(false);
+
+  const start = useCallback(() => {
+    firedRef.current = false;
+    timerRef.current = setTimeout(() => {
+      firedRef.current = true;
+      onLongPress();
+    }, LONG_PRESS_MS);
+  }, [onLongPress]);
+
+  const end = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (!firedRef.current) {
+      onTap();
+    }
+  }, [onTap]);
+
+  const cancel = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  return {
+    onTouchStart: start,
+    onTouchEnd: end,
+    onTouchCancel: cancel,
+  };
+}

--- a/frontend/src/hooks/use-shake-escalation.ts
+++ b/frontend/src/hooks/use-shake-escalation.ts
@@ -1,0 +1,116 @@
+import { useRef, useCallback, useEffect } from 'react';
+
+const HOLD_DURATION = 5000;
+const TAP_THRESHOLD = 300;
+
+/**
+ * Progressive shake on hold: gentle wiggle that escalates over 5 s,
+ * then fires onLongPress. Short taps play a quick wiggle and fire onTap.
+ */
+export function useShakeEscalation(
+  onTap: () => void,
+  onLongPress: () => void,
+) {
+  const elementRef = useRef<HTMLImageElement>(null);
+  const startTimeRef = useRef(0);
+  const rafRef = useRef(0);
+  const activeRef = useRef(false);
+  const firedRef = useRef(false);
+  const tapRafRef = useRef(0);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      if (tapRafRef.current) cancelAnimationFrame(tapRafRef.current);
+    };
+  }, []);
+
+  const clearHold = useCallback(() => {
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = 0;
+    }
+    activeRef.current = false;
+    if (elementRef.current) elementRef.current.style.transform = '';
+  }, []);
+
+  const tick = useCallback(
+    (now: number) => {
+      if (!activeRef.current || !elementRef.current) return;
+
+      const elapsed = now - startTimeRef.current;
+      const progress = Math.min(elapsed / HOLD_DURATION, 1);
+
+      // Quadratic ease-in: first seconds are subtle, last seconds are frantic
+      const t = progress * progress;
+      const speed = 0.015 + progress * 0.035;
+      const rotateAmp = 2 + t * 13; // 2 deg -> 15 deg
+      const translateAmp = t * 3; // 0 px -> 3 px
+
+      const angle = Math.sin(elapsed * speed) * rotateAmp;
+      const tx = Math.cos(elapsed * speed * 1.3) * translateAmp;
+
+      elementRef.current.style.transform = `rotate(${angle.toFixed(2)}deg) translateX(${tx.toFixed(2)}px)`;
+
+      if (progress >= 1 && !firedRef.current) {
+        firedRef.current = true;
+        clearHold();
+        onLongPress();
+        return;
+      }
+
+      rafRef.current = requestAnimationFrame(tick);
+    },
+    [onLongPress, clearHold],
+  );
+
+  const playTapWiggle = useCallback(() => {
+    const el = elementRef.current;
+    if (!el) return;
+    if (tapRafRef.current) cancelAnimationFrame(tapRafRef.current);
+
+    const start = performance.now();
+    const animate = (now: number) => {
+      const t = now - start;
+      if (t >= 400) {
+        el.style.transform = '';
+        return;
+      }
+      const decay = 1 - t / 400;
+      const angle = Math.sin(t * 0.05) * 8 * decay;
+      el.style.transform = `rotate(${angle.toFixed(2)}deg)`;
+      tapRafRef.current = requestAnimationFrame(animate);
+    };
+    tapRafRef.current = requestAnimationFrame(animate);
+  }, []);
+
+  const onTouchStart = useCallback(() => {
+    firedRef.current = false;
+    activeRef.current = true;
+    startTimeRef.current = performance.now();
+    rafRef.current = requestAnimationFrame(tick);
+  }, [tick]);
+
+  const onTouchEnd = useCallback(() => {
+    const elapsed = performance.now() - startTimeRef.current;
+    clearHold();
+    if (!firedRef.current) {
+      if (elapsed < TAP_THRESHOLD) playTapWiggle();
+      onTap();
+    }
+  }, [onTap, clearHold, playTapWiggle]);
+
+  const onTouchCancel = useCallback(() => {
+    clearHold();
+  }, [clearHold]);
+
+  return {
+    ref: elementRef,
+    handlers: {
+      onTouchStart,
+      onTouchEnd,
+      onTouchCancel,
+      onContextMenu: (e: React.MouseEvent) => e.preventDefault(),
+    },
+  };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -124,6 +124,7 @@
   body {
     @apply bg-background text-foreground;
     font-family: var(--font-body);
+    overflow-x: hidden;
   }
 
   h1, h2, h3, h4, h5, h6 {

--- a/frontend/src/pages/CartPage.tsx
+++ b/frontend/src/pages/CartPage.tsx
@@ -170,7 +170,7 @@ const CartPage = () => {
           <>
             {/* Selected recipes */}
             <div className="space-y-2">
-              <h3 className="font-display text-base font-semibold text-muted-foreground uppercase tracking-wide">
+              <h3 className="font-body text-base font-semibold text-muted-foreground uppercase tracking-wide">
                 Recettes sélectionnées
               </h3>
               {cartRecipes.map((recipe) => (
@@ -198,7 +198,7 @@ const CartPage = () => {
             {/* Shopping list */}
             {ingredients.length > 0 && (
               <div className="space-y-2">
-                <h3 className="font-display text-base font-semibold text-muted-foreground uppercase tracking-wide">
+                <h3 className="font-body text-base font-semibold text-muted-foreground uppercase tracking-wide">
                   Liste de courses
                 </h3>
                 <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>

--- a/frontend/src/pages/CartPage.tsx
+++ b/frontend/src/pages/CartPage.tsx
@@ -158,7 +158,7 @@ const CartPage = () => {
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-20 flex items-center justify-center px-4 h-14 bg-background border-b border-border md:hidden">
-        <h1 className="font-display text-lg font-bold text-foreground">Panier ({count})</h1>
+        <h1 className="font-display text-xl font-bold text-foreground">Panier ({count})</h1>
       </header>
 
       <main className="max-w-lg mx-auto px-4 py-4 pb-24 space-y-6">
@@ -170,26 +170,26 @@ const CartPage = () => {
           <>
             {/* Selected recipes */}
             <div className="space-y-2">
-              <h3 className="font-display text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+              <h3 className="font-display text-base font-semibold text-muted-foreground uppercase tracking-wide">
                 Recettes sélectionnées
               </h3>
               {cartRecipes.map((recipe) => (
-                <div key={recipe.id} className="flex items-center gap-3 p-2 rounded-lg bg-secondary/50 group">
+                <div key={recipe.id} className="flex items-center gap-3 p-3 rounded-lg bg-secondary/50 group">
                   {recipe.image ? (
-                    <AuthImage src={recipe.image} alt={recipe.title} className="w-12 h-12 rounded object-cover shrink-0" />
+                    <AuthImage src={recipe.image} alt={recipe.title} className="w-14 h-14 rounded-md object-cover shrink-0" />
                   ) : (
-                    <div className="w-12 h-12 rounded bg-muted shrink-0" />
+                    <div className="w-14 h-14 rounded-md bg-muted shrink-0" />
                   )}
                   <div className="flex-1 min-w-0">
-                    <p className="font-body text-sm font-medium truncate">{recipe.title}</p>
-                    <p className="text-xs text-muted-foreground font-body">{recipe.servings} pers. · {recipe.ingredients.length} ingrédients</p>
+                    <p className="font-body text-base font-medium truncate">{recipe.title}</p>
+                    <p className="text-sm text-muted-foreground font-body">{recipe.servings} pers. · {recipe.ingredients.length} ingrédients</p>
                   </div>
                   <button
                     onClick={() => remove(recipe.id)}
-                    className="shrink-0 p-1.5 rounded-full text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+                    className="shrink-0 p-2 rounded-full text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
                     title="Retirer du panier"
                   >
-                    <X size={16} />
+                    <X size={20} />
                   </button>
                 </div>
               ))}
@@ -198,12 +198,12 @@ const CartPage = () => {
             {/* Shopping list */}
             {ingredients.length > 0 && (
               <div className="space-y-2">
-                <h3 className="font-display text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+                <h3 className="font-display text-base font-semibold text-muted-foreground uppercase tracking-wide">
                   Liste de courses
                 </h3>
                 <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
                   <SortableContext items={sortedIngredients.map((i) => i.id)} strategy={verticalListSortingStrategy}>
-                    <ul className="space-y-1">
+                    <ul className="space-y-1.5">
                       {sortedIngredients.map((ing) => (
                         <SortableCartIngredientItem
                           key={ing.id}
@@ -223,12 +223,12 @@ const CartPage = () => {
 
             {/* Actions */}
             <div className="space-y-2">
-              <Button onClick={copyShoppingList} className="w-full gradient-warm text-primary-foreground font-body font-semibold gap-2">
-                <ClipboardCopy size={16} />
+              <Button onClick={copyShoppingList} className="w-full gradient-warm text-primary-foreground font-body font-semibold gap-2 h-12 text-base">
+                <ClipboardCopy size={20} />
                 Copier la liste de courses
               </Button>
-              <Button onClick={clear} variant="ghost" className="w-full font-body text-muted-foreground gap-2">
-                <Trash2 size={16} />
+              <Button onClick={clear} variant="ghost" className="w-full font-body text-muted-foreground gap-2 h-12 text-base">
+                <Trash2 size={20} />
                 Vider le panier
               </Button>
             </div>

--- a/frontend/src/pages/CatalogPage.tsx
+++ b/frontend/src/pages/CatalogPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useEffect, useState, useCallback, lazy, Suspense } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Plus, PenLine, Camera, Instagram, Download, FileDown, FileText, FileJson, X, ArrowUpDown, Check, Share2, Inbox } from 'lucide-react';
-import { useShake } from '@/hooks/use-shake';
+
 
 const BeaverCatchGame = lazy(() => import('@/components/BeaverCatchGame'));
 import CartSheet from '@/components/CartSheet';
@@ -86,7 +86,6 @@ const CatalogPage = () => {
     setSelectedRecipes(new Set());
   }, []);
   const openBeaverGame = useCallback(() => setShowBeaverGame(true), []);
-  useShake(openBeaverGame);
 
   // Dev shortcut: Shift+B to test the easter egg on desktop
   useEffect(() => {
@@ -231,6 +230,8 @@ const CatalogPage = () => {
         hasActiveFilters={hasActiveFilters}
         inlineSearch={inlineSearch}
         onInlineSearchChange={setInlineSearch}
+        onLogoTap={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+        onLogoLongPress={openBeaverGame}
       />
 
       {/* Mobile search overlay */}

--- a/frontend/src/pages/CreateRecipePage.tsx
+++ b/frontend/src/pages/CreateRecipePage.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecipes, useCreateRecipe, useUpdateRecipe } from '@/hooks/use-recipes';
 import RecipeForm from '@/components/RecipeForm';
 import { toast } from '@/hooks/use-toast';
 import { Recipe } from '@/data/recipes';
+import { useOverlayClose } from '@/components/CatalogLayout';
 
 const CreateRecipePage = () => {
   const navigate = useNavigate();
@@ -11,6 +12,8 @@ const CreateRecipePage = () => {
   const createMutation = useCreateRecipe();
   const updateMutation = useUpdateRecipe();
   const [customTags, setCustomTags] = useState<string[]>([]);
+  const { requestClose } = useOverlayClose();
+  const handleBack = useCallback(() => requestClose('/'), [requestClose]);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -53,7 +56,7 @@ const CreateRecipePage = () => {
 
   return (
     <RecipeForm
-      onBack={() => navigate('/add')}
+      onBack={handleBack}
       onSave={handleSave}
       allTags={allTags}
       onAddTag={handleAddTag}

--- a/frontend/src/pages/CreateRecipePage.tsx
+++ b/frontend/src/pages/CreateRecipePage.tsx
@@ -53,7 +53,7 @@ const CreateRecipePage = () => {
 
   return (
     <RecipeForm
-      onBack={() => navigate('/')}
+      onBack={() => navigate('/add')}
       onSave={handleSave}
       allTags={allTags}
       onAddTag={handleAddTag}

--- a/frontend/src/pages/ImportInstagramPage.tsx
+++ b/frontend/src/pages/ImportInstagramPage.tsx
@@ -8,7 +8,7 @@ const ImportInstagramPage = () => {
 
   return (
     <RecipeImportInstagram
-      onBack={() => navigate('/')}
+      onBack={() => navigate('/add')}
       onImportDone={() => {
         queryClient.invalidateQueries({ queryKey: ['recipes'] });
         navigate('/');

--- a/frontend/src/pages/ImportJSONPage.tsx
+++ b/frontend/src/pages/ImportJSONPage.tsx
@@ -9,7 +9,7 @@ const ImportJSONPage = () => {
 
   return (
     <RecipeImportJSON
-      onBack={() => navigate('/')}
+      onBack={() => navigate('/add')}
       onImportRecipes={() => {
         queryClient.invalidateQueries({ queryKey: ['recipes'] });
         toast({ title: 'Import terminé !' });

--- a/frontend/src/pages/ImportOCRPage.tsx
+++ b/frontend/src/pages/ImportOCRPage.tsx
@@ -9,7 +9,7 @@ const ImportOCRPage = () => {
 
   return (
     <RecipeImportOCR
-      onBack={() => navigate('/')}
+      onBack={() => navigate('/add')}
       onImportRecipes={(imported) => {
         queryClient.invalidateQueries({ queryKey: ['recipes'] });
         toast({ title: `${imported.length} recette${imported.length > 1 ? 's' : ''} importée${imported.length > 1 ? 's' : ''} !` });

--- a/frontend/src/pages/RecipeDetailPage.tsx
+++ b/frontend/src/pages/RecipeDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRecipe, useRecipes, useUpdateRecipe, useDeleteRecipe, useCreateRecipe } from '@/hooks/use-recipes';
@@ -8,6 +8,7 @@ import { toast } from '@/hooks/use-toast';
 import { useCart } from '@/contexts/CartContext';
 import { Recipe } from '@/data/recipes';
 import { leaveRecipe, fetchImageAsDataUrl } from '@/lib/api';
+import { useOverlayClose } from '@/components/CatalogLayout';
 
 const RecipeDetailPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -22,6 +23,8 @@ const RecipeDetailPage = () => {
   const queryClient = useQueryClient();
   const [customTags, setCustomTags] = useState<string[]>([]);
   const initialEditing = !!(location.state as { edit?: boolean })?.edit;
+  const { requestClose } = useOverlayClose();
+  const handleBack = useCallback(() => requestClose('/'), [requestClose]);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -169,7 +172,7 @@ const RecipeDetailPage = () => {
   return (
     <RecipeDetail
       recipe={recipe}
-      onBack={() => navigate('/')}
+      onBack={handleBack}
       onRatingChange={recipe.userRole !== 'reader' ? handleRatingChange : undefined}
       onSave={recipe.userRole !== 'reader' ? handleSave : undefined}
       onTestedToggle={recipe.userRole !== 'reader' ? handleTestedToggle : undefined}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,6 +1,5 @@
-import { useNavigate } from 'react-router-dom';
 import { useTheme } from 'next-themes';
-import { Sun, Moon, Monitor, Check, LogOut, User, ArrowLeft } from 'lucide-react';
+import { Sun, Moon, Monitor, Check, LogOut, User } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useAccentColor, ACCENT_COLORS, type AccentColor } from '@/contexts/ThemeContext';
 import { Button } from '@/components/ui/button';
@@ -10,7 +9,6 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 const colorKeys = Object.keys(ACCENT_COLORS) as AccentColor[];
 
 export default function SettingsPage() {
-  const navigate = useNavigate();
   const { user, logout } = useAuth();
   const { theme, setTheme } = useTheme();
   const { accentColor, setAccentColor } = useAccentColor();
@@ -18,11 +16,8 @@ export default function SettingsPage() {
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
-      <header className="sticky top-0 z-20 flex items-center px-4 h-14 bg-background border-b border-border">
-        <Button variant="ghost" size="icon" className="shrink-0" onClick={() => navigate('/')}>
-          <ArrowLeft size={18} />
-        </Button>
-        <h1 className="font-display text-lg font-bold text-foreground flex-1 text-center mr-9">Paramètres</h1>
+      <header className="sticky top-0 z-20 flex items-center justify-center px-4 h-14 bg-background border-b border-border md:hidden">
+        <h1 className="font-display text-lg font-bold text-foreground">Paramètres</h1>
       </header>
 
       <main className="max-w-lg mx-auto px-4 py-6 pb-24 md:pb-6 space-y-8">

--- a/frontend/src/pages/SharesPage.tsx
+++ b/frontend/src/pages/SharesPage.tsx
@@ -9,9 +9,7 @@ const SharesPage = () => {
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-20 flex items-center justify-center px-4 h-14 bg-background border-b border-border md:hidden">
-        <h1 className="font-display text-lg font-bold text-foreground flex items-center gap-2">
-          <Share2 size={20} /> Partages
-        </h1>
+        <h1 className="font-display text-lg font-bold text-foreground">Partages</h1>
       </header>
 
       <main className="max-w-lg mx-auto px-4 py-6 space-y-3 pb-24">

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -105,6 +105,14 @@ export default {
           "50%": { transform: "scale(1.2) translateY(-4px)" },
           "100%": { opacity: "1", transform: "scale(1) translateY(0)" },
         },
+        "slide-in-from-right": {
+          from: { transform: "translateX(100%)" },
+          to: { transform: "translateX(0)" },
+        },
+        "slide-out-to-right": {
+          from: { transform: "translateX(0)" },
+          to: { transform: "translateX(100%)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
@@ -112,6 +120,8 @@ export default {
         "fade-in": "fade-in 0.4s ease-out",
         "scale-in": "scale-in 0.3s ease-out",
         "bounce-in": "bounce-in 0.25s ease-out",
+        "slide-in-from-right": "slide-in-from-right 0.3s ease-out both",
+        "slide-out-to-right": "slide-out-to-right 0.3s ease-out forwards",
       },
     },
   },


### PR DESCRIPTION
# Summary

- Slide-in/out page transitions on mobile: Recipe detail and create pages now render as overlays with horizontal slide animations via a new CatalogLayout wrapper, replacing full-page navigations
- Larger touch targets across the app: Bumped icon sizes, buttons, checkboxes, and tap areas in cart, shopping list, and bottom bar for better mobile usability (16px -> 20px icons, bigger paddings, h-12 buttons)
- Logo interactions: Tap scrolls to top, long press (5s with escalating shake animation) opens the beaver easter egg game — replaces the previous device-shake trigger
- Bottom bar tap feedback: Added a pill-flash animation when tapping nav tabs
- JSON import paste mode: Users can now paste JSON directly in addition to uploading a file
- Visual polish: Fixed star colors for unrated recipes (text-white/30), removed gray/desaturated styling on untested recipes, switched section headers to font-body, simplified page headers (Settings, Shares), fixed search overlay to slide horizontally
- Navigation fixes: Import pages (OCR, JSON, Instagram) now go back to /add instead of /